### PR TITLE
Fix typeSelector.PkgPath giving inconsistent result for type alias

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -118,7 +118,7 @@ func (r *parser) parseType(info *infoFile, decl *ast.GenDecl) {
 		if s.Assign == 0 && tt.Kind() != Interface {
 			tt = newTypeNamed(s.Name.Name, tt, info)
 		} else {
-			tt = newTypeAlias(s.Name.Name, tt)
+			tt = newTypeAlias(s.Name.Name, tt, info)
 		}
 
 		tt = newTypeOrigin(tt, s, r.info, doc, comment)

--- a/types_alias.go
+++ b/types_alias.go
@@ -1,14 +1,16 @@
 package gotype
 
-func newTypeAlias(name string, typ Type) Type {
+func newTypeAlias(name string, typ Type, info *infoFile) Type {
 	return &typeAlias{
 		name: name,
+		info: info,
 		Type: typ,
 	}
 }
 
 type typeAlias struct {
 	name string
+	info *infoFile
 	Type
 }
 
@@ -18,4 +20,8 @@ func (t *typeAlias) Name() string {
 
 func (t *typeAlias) String() string {
 	return t.name
+}
+
+func (t *typeAlias) PkgPath() string {
+	return t.info.PkgPath
 }


### PR DESCRIPTION
Hi! Thanks for your awesome work! This PR tries to fix `typeSelector.PkgPath` giving inconsistent result between package and type, by directly returning the package path from `x` instead of going through `child`.

Details
-------
The problem is that, type alias identifiers from one package can reference types from another.

For this example, there is **typeSelector**{  **x**=`package b`, **child**=`type A` }. In this case, `typeSelector.PkgPath()` returns `a` but `typeSelector.Name()` returns `B`, causing inconsistency between type name and package. Not sure if this is intended?

```go
package a

type A struct {}
```

```go
package b

import "a"

type B = a.A
```

```go
pkg, _ := importer.Import("b", "")
alias, _ := pkg.ChildByName("B")

alias.Name()    // "B"
alias.PkgPath() // "a"
```

Result
-------
By applying this change, `PkgPath()` should be consistent with `String()`.
Changes to made:
https://github.com/wzshiming/gotype/blob/5ce2539a977c61defe53a38f8707da3045a34e8b/types_selector.go#L65-L67

Current String method:
https://github.com/wzshiming/gotype/blob/5ce2539a977c61defe53a38f8707da3045a34e8b/types_selector.go#L61-L63